### PR TITLE
Permit unicode-display_width 1.x dependency

### DIFF
--- a/hirb-unicode-steakknife.gemspec
+++ b/hirb-unicode-steakknife.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Unicode support for hirb}
 
   s.add_dependency 'hirb', '~> 0.5'
-  s.add_dependency 'unicode-display_width', '>= 0.2.0', '< 1.0'
+  s.add_dependency 'unicode-display_width', '>= 0.2.0', '< 2.0'
   # Use the same test utility as `hirb`
   s.add_development_dependency 'bacon', '>= 1.1.0'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
1.x has internal changes and a require is removed that hirb-unicode
isn't using.  It also requires Ruby 1.9.3+ or higher.